### PR TITLE
Fix Notification Override

### DIFF
--- a/lib/notification_services.dart
+++ b/lib/notification_services.dart
@@ -137,7 +137,7 @@ class NotificationServices {
 
     Future.delayed(Duration.zero , (){
       _flutterLocalNotificationsPlugin.show(
-          0,
+          message.hashCode, // Unique ID for the notification
           message.notification!.title.toString(),
           message.notification!.body.toString(),
           notificationDetails ,


### PR DESCRIPTION
Using 0 as the notification ID can lead to issues if you display multiple notifications, as it will overwrite any existing notification with the same ID. This can result in lost notifications and confusion in managing them.

By changing it to message.hashCode, you ensure that each notification has a unique identifier based on the message content, allowing multiple notifications to be displayed simultaneously without conflicts. This improves notification management and ensures that users receive all relevant alerts.